### PR TITLE
Add billing_info field to address form

### DIFF
--- a/src/components/composite/Address/AddressInputGroup/index.tsx
+++ b/src/components/composite/Address/AddressInputGroup/index.tsx
@@ -30,9 +30,11 @@ interface Props {
     | "country_code"
     | "state_code"
     | "phone"
+    | "billing_info"
   >}`
   resource: ResourceErrorType
   value?: string
+  required?: boolean
 }
 
 export const AddressInputGroup: React.FC<Props> = ({
@@ -40,6 +42,7 @@ export const AddressInputGroup: React.FC<Props> = ({
   resource,
   type,
   value,
+  required,
 }) => {
   const { t } = useTranslation()
 
@@ -123,6 +126,7 @@ export const AddressInputGroup: React.FC<Props> = ({
             name={fieldName}
             type={type}
             value={valueStatus}
+            required={required}
             className="form-input"
           />
           <Label htmlFor={fieldName}>{label}</Label>

--- a/src/components/composite/Address/CustomerAddressForm/index.tsx
+++ b/src/components/composite/Address/CustomerAddressForm/index.tsx
@@ -90,6 +90,13 @@ const CustomerAddressForm: React.FC<Props> = ({ onClose }) => {
         type="tel"
         value={address?.phone || ""}
       />
+      <AddressInputGroup
+        required={false}
+        fieldName="billing_address_billing_info"
+        resource="billing_address"
+        type="text"
+        value={address?.billing_info || ""}
+      />
       <FormButtons>
         <DiscardChanges onClick={onClose}>
           <XCircle className="w-4 h-4" />


### PR DESCRIPTION
### What does this PR do?
Introduce `billing_info` field to address form. (closes #80)

### Description of Task to be completed
A new react component of kind `AddressInput` is added to Addresses create/update form in order to introduce an additional field related `billing_info` address field. Because of the field's unique behaviour managed by react component library, an updated version of the `AddressInput` react component was requested to enable it to be always visible without any constraints when needed. This is now possible thanks to `AddressInput`'s new boolean prop `required` that can be set to `false` to disable constraints.

<img width="1046" alt="Screenshot 2022-12-12 alle 16 47 26" src="https://user-images.githubusercontent.com/105653649/207089885-12db75af-96df-49ab-a7c9-b8fc6410009e.png">
