### PR TITLE
Fix app to read api domain from config

### DIFF
--- a/packages/my-account/src/App.tsx
+++ b/packages/my-account/src/App.tsx
@@ -30,7 +30,7 @@ function App(): JSX.Element {
                 ) : !settings.isValid ? (
                   <Invalid />
                 ) : (
-                  <MyAccountContainer settings={settings}>
+                  <MyAccountContainer settings={settings} config={config}>
                     <Switch>
                       <Route path={"/404"}>
                         <Invalid />

--- a/packages/my-account/src/components/composite/MyAccountContainer/index.tsx
+++ b/packages/my-account/src/components/composite/MyAccountContainer/index.tsx
@@ -18,9 +18,14 @@ import { CustomerContainerProvider } from "#providers/CustomerContainerProvider"
 interface Props {
   settings: Settings
   children: React.ReactElement
+  config: RuntimeConfig
 }
 
-function MyAccountContainer({ settings, children }: Props): JSX.Element {
+function MyAccountContainer({
+  settings,
+  children,
+  config,
+}: Props): JSX.Element {
   return (
     <>
       <PageHead
@@ -44,6 +49,7 @@ function MyAccountContainer({ settings, children }: Props): JSX.Element {
               customerId={settings.customerId}
               accessToken={settings.accessToken}
               endpoint={settings.endpoint}
+              domain={config.domain}
             >
               <CustomerContainerProvider isGuest={settings.isGuest}>
                 <LayoutDefault

--- a/packages/my-account/src/pages/OrderPage/index.tsx
+++ b/packages/my-account/src/pages/OrderPage/index.tsx
@@ -36,7 +36,11 @@ function OrderPage({ orderId }: OrderPageProps): JSX.Element {
   const orderStatus = order ? (order.status as OrderStatus) : "placed"
 
   return (
-    <OrderProvider orderId={orderId} accessToken={accessToken as string}>
+    <OrderProvider
+      orderId={orderId}
+      accessToken={accessToken as string}
+      domain={ctx?.domain as string}
+    >
       {({ invalidOrder }) => {
         if (invalidOrder) {
           return <Redirect to={`/orders?accessToken=${accessToken}`} />

--- a/packages/my-account/src/pages/ParcelPage/index.tsx
+++ b/packages/my-account/src/pages/ParcelPage/index.tsx
@@ -5,6 +5,7 @@ import { Shipment } from "@commercelayer/react-components/shipments/Shipment"
 import { ShipmentsContainer } from "@commercelayer/react-components/shipments/ShipmentsContainer"
 import type { Settings } from "HostedApp"
 import { CaretLeft } from "phosphor-react"
+import { useContext } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, Redirect } from "wouter"
 
@@ -23,6 +24,7 @@ import {
 
 import OrderParcelHistory from "#components/composite/OrderParcel/OrderParcelHistory"
 import { SkeletonMainParcel } from "#components/composite/Skeleton/Main"
+import { AppContext } from "#providers/AppProvider"
 import { OrderProvider } from "#providers/OrderProvider"
 
 interface Props {
@@ -32,10 +34,15 @@ interface Props {
 }
 
 function ParcelPage({ settings, orderId, parcelId }: Props): JSX.Element {
+  const ctx = useContext(AppContext)
   const { t } = useTranslation()
 
   return (
-    <OrderProvider orderId={orderId} accessToken={settings.accessToken}>
+    <OrderProvider
+      orderId={orderId}
+      accessToken={settings.accessToken}
+      domain={ctx?.domain as string}
+    >
       {({ invalidOrder }) => {
         if (invalidOrder) {
           return <Redirect to={`/orders?accessToken=${settings.accessToken}`} />

--- a/packages/my-account/src/providers/AppProvider/index.tsx
+++ b/packages/my-account/src/providers/AppProvider/index.tsx
@@ -9,6 +9,7 @@ type AppProviderData = Pick<
   Settings,
   "customerId" | "accessToken" | "endpoint"
 > & {
+  domain: string
   email: string
   hasPassword: boolean
   isLoading: boolean
@@ -41,6 +42,7 @@ type AppProviderProps = Pick<
   Settings,
   "customerId" | "accessToken" | "endpoint"
 > & {
+  domain: string
   children: React.ReactNode
 }
 
@@ -49,6 +51,7 @@ export function AppProvider({
   customerId,
   accessToken,
   endpoint,
+  domain,
 }: AppProviderProps): JSX.Element {
   const [state, setState] = useState(initialState)
 
@@ -65,8 +68,6 @@ export function AppProvider({
     if (!slug) {
       return
     }
-
-    const domain = import.meta.env.PUBLIC_DOMAIN || "commercelayer.io"
 
     const client = CommerceLayer({
       organization: slug,
@@ -103,6 +104,7 @@ export function AppProvider({
         customerId,
         accessToken,
         endpoint,
+        domain,
         refetchCustomer: async () => {
           return await fetchCustomerHandle(customerId, accessToken)
         },

--- a/packages/my-account/src/providers/OrderProvider/index.tsx
+++ b/packages/my-account/src/providers/OrderProvider/index.tsx
@@ -24,6 +24,7 @@ export const OrderContext = createContext<OrderProviderData | null>(null)
 type OrderProviderProps = {
   orderId: string
   accessToken: string
+  domain: string
   children: ((props: OrderProviderData) => React.ReactNode) | React.ReactNode
 }
 
@@ -31,6 +32,7 @@ export function OrderProvider({
   children,
   orderId,
   accessToken,
+  domain,
 }: OrderProviderProps): JSX.Element {
   const [state, setState] = useState(initialState)
 
@@ -43,8 +45,6 @@ export function OrderProvider({
     if (!slug) {
       return
     }
-
-    const domain = import.meta.env.PUBLIC_DOMAIN || "commercelayer.io"
 
     const cl = CommerceLayer({
       organization: slug,


### PR DESCRIPTION
### What does this PR do?
Refactor the application to read API domain from config instead of reading it from environment variable. The config domain is then shared to components by AppContext.