### PR TITLE
Fix position of closeMobileMenu event

### DIFF
--- a/packages/my-account/src/components/composite/NavLink/index.tsx
+++ b/packages/my-account/src/components/composite/NavLink/index.tsx
@@ -48,10 +48,11 @@ function NavLink(props: Props): JSX.Element {
   if (comingSoon) return <NavLinkButton {...props} />
 
   return (
-    <Link href={`${href}?accessToken=${accessToken}`}>
-      <a onClick={() => ctx?.closeMobileMenu()}>
-        <NavLinkButton {...props} />
-      </a>
+    <Link
+      href={`${href}?accessToken=${accessToken}`}
+      onClick={() => ctx?.closeMobileMenu()}
+    >
+      <NavLinkButton {...props} />
     </Link>
   )
 }


### PR DESCRIPTION
### What does this PR do?
Move `closeMobileMenu` `onClick` event to parent `<Link>` component instead of old `<Link><a>`.
Wouter `Link` component does not consider child `a` element as it is for NextJS `Link` component.