### PR TITLE
Show shipments statuses based on shipment status groups

### DIFF
--- a/packages/my-account/src/assets/locales/en/common.json
+++ b/packages/my-account/src/assets/locales/en/common.json
@@ -140,13 +140,9 @@
     "cancelled": "cancelled"
   },
   "shipmentStatus": {
-    "draft": "draft",
     "upcoming": "upcoming",
+    "in_progress": "in progress",
     "cancelled": "cancelled",
-    "on_hold": "on_hold",
-    "picking": "picking",
-    "packing": "packing",
-    "ready_to_ship": "ready_to_ship",
     "shipped": "shipped"
   },
   "parcelStatus": {

--- a/packages/my-account/src/assets/locales/it/common.json
+++ b/packages/my-account/src/assets/locales/it/common.json
@@ -140,14 +140,10 @@
     "cancelled": "cancelled"
   },
   "shipmentStatus": {
-    "draft": "draft",
-    "upcoming": "upcoming",
-    "cancelled": "cancelled",
-    "on_hold": "on_hold",
-    "picking": "picking",
-    "packing": "packing",
-    "ready_to_ship": "ready_to_ship",
-    "shipped": "shipped"
+    "upcoming": "imminente",
+    "in_progress": "in preparazione",
+    "cancelled": "cancellata",
+    "shipped": "spedita"
   },
   "parcelStatus": {
     "delivered": "Consegnato",

--- a/packages/my-account/src/components/ui/StatusChip/ShipmentStatusChip/index.tsx
+++ b/packages/my-account/src/components/ui/StatusChip/ShipmentStatusChip/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 
 import StatusChip from "#components/ui/StatusChip"
+import { getStatusTranslations } from "#utils/shipments"
 
 export type ShipmentStatus =
   | "draft"
@@ -20,12 +21,7 @@ function ShipmentStatusChip({ status }: Props): JSX.Element {
   if (status === undefined) return <></>
   const { t } = useTranslation()
 
-  return (
-    <StatusChip
-      status={status}
-      label={t(`shipmentStatus.${status}`) as string}
-    />
-  )
+  return <StatusChip status={status} label={getStatusTranslations(status, t)} />
 }
 
 export default ShipmentStatusChip

--- a/packages/my-account/src/utils/shipments.ts
+++ b/packages/my-account/src/utils/shipments.ts
@@ -1,0 +1,27 @@
+/**
+ * Retrieves the correct translation of a shipment status depending on statuses regroupments defined internally.
+ *
+ * @param value - The shipment status
+ * @param t - Instance of React i18next useTranslation hook
+ *
+ * @returns a string containing the calculated translation of shipment status, if set, or the
+ * starting value to search a translation for if no corresponding translation is available.
+ */
+export function getStatusTranslations(value: string, t: (a: string) => string) {
+  switch (value) {
+    case "on_hold":
+    case "upcoming":
+    case "draft":
+      return t("shipmentStatus.upcoming")
+    case "picking":
+    case "packing":
+    case "ready_to_ship":
+      return t("shipmentStatus.in_progress")
+    case "cancelled":
+      return t("shipmentStatus.cancelled")
+    case "shipped":
+      return t("shipmentStatus.shipped")
+    default:
+      return value || ""
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Refactor shipments statuses to show suitable status translations based on internally defined shipment status groups, hiding to customer internal purpose detailed statuses.

<img width="645" alt="Screenshot 2022-12-20 alle 10 32 09" src="https://user-images.githubusercontent.com/105653649/208633129-0ec54dc8-d65c-4395-b7df-5e03f449e08f.png">
