### PR TITLE
Fix getSettings documentation of defaultSettings variable

### DIFF
--- a/packages/my-account/src/utils/getSettings.ts
+++ b/packages/my-account/src/utils/getSettings.ts
@@ -5,7 +5,7 @@ import { getInfoFromJwt } from "#utils/getInfoFromJwt"
 import { getOrganizations } from "#utils/getOrganizations"
 import { isValidHost } from "#utils/isValidHost"
 
-// default settings are by their nature not valid to show a full cart
+// default settings are by their nature not valid to show My Account data
 // they will be used as fallback for errors or 404 page
 export const defaultSettings: InvalidSettings = {
   isValid: false,


### PR DESCRIPTION
### What does this PR do?
Fix `#utils/getSettings` docs comment of `defaultSettings` variable. A copy/paste error containing a reference to cart app is replaced with the correct reference to My Account app.