### PR TITLE
Remove unwanted hover effects of `AddressCard`s and Order detail page sections titles

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   "useWorkspaces": true,
   "command": {
     "version": {
-      "preid": "beta"
+      "preid": "stg"
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2",
+  "version": "1.1.3-stg.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",

--- a/packages/my-account/package.json
+++ b/packages/my-account/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mfe-my-account",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3-stg.0",
   "engines": {
     "node": ">=16",
     "pnpm": ">=7"

--- a/packages/my-account/src/components/ui/AddressCard/index.tsx
+++ b/packages/my-account/src/components/ui/AddressCard/index.tsx
@@ -80,7 +80,7 @@ export function AddressCard({
           </ConfirmActions>
         </Overlay>
       )}
-      <GridCard>
+      <GridCard hover={readonly ? "none" : undefined}>
         <Customer data-cy={`fullname_${addressType}`}>
           {first_name} {last_name}
         </Customer>

--- a/packages/my-account/src/components/ui/OrderSection/styled.tsx
+++ b/packages/my-account/src/components/ui/OrderSection/styled.tsx
@@ -8,7 +8,7 @@ export const OrderSectionTab = styled.div`
   ${tw`outline-none bg-white shadow-bottom px-5 md:px-0 mb-6 md:mb-0 md:shadow-none md:border-b`}
 `
 export const OrderSectionTabHeader = styled.div`
-  ${tw`text-black relative flex items-center justify-between cursor-pointer transition ease duration-500 focus:bg-gray-400`}
+  ${tw`text-black relative flex items-center justify-between transition ease duration-500 focus:bg-gray-400`}
   .disabled & {
     ${tw`pointer-events-none`}
   }


### PR DESCRIPTION
Closes #130 
Closes #131 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

1. Updated `AddressCard` component to use its `readonly` prop to set `GridCard`'s hover behavior
2. Removed `cursor-pointer` cursor style in order detail sections headers

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
