### PR TITLE
Calculate subscriptions progress bar starting from `last_run_at` attribute

### DIFF
--- a/packages/my-account/src/components/composite/Subscription/SubscriptionNextRunProgress/index.tsx
+++ b/packages/my-account/src/components/composite/Subscription/SubscriptionNextRunProgress/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 function getProgressMax(subscription: OrderSubscription) {
   const distance = formatDistanceStrict(
     new Date(subscription.next_run_at as string),
-    new Date(subscription.starts_at as string),
+    new Date(subscription.last_run_at as string),
     { unit: "minute" }
   )
   return parseInt(distance.split(" ")[0]) ?? 0


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I fixed subscriptions' progress bar edges calculation in order to have the start relying on the `last_run_at` attribute.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
