### PR TITLE
Add optional `Back to shop` navigation link

### DIFF
--- a/packages/my-account/README.md
+++ b/packages/my-account/README.md
@@ -12,6 +12,7 @@ The Commerce Layer My Account application (React) provides a production-ready re
 
 - [Getting started](#getting-started)
 - [Hosted version](#hosted-version)
+- [Localization](#localization)
 - [Features](#features)
 - [Using the CLI to get a valid customer token](#using-the-cli-to-get-a-valid-customer-token)
 - [Contributors guide](#contributors-guide)
@@ -51,7 +52,7 @@ You can use the hosted version of the My Account application with the following 
 ## Localization
 
 The application is actually localized in `en`, `it` and `nl` locales.
-You could optionally provide an optional `lang` URL parameter to define the locale used to localize the app: `https://<your-organization-subdomain>.commercelayer.app/my-account/?accessToken=<your-access-token>&lang=<short-lang-code>`
+You could optionally provide a `lang` URL parameter to define the locale used to localize the app: `https://<your-organization-subdomain>.commercelayer.app/my-account/?accessToken=<your-access-token>&lang=<short-lang-code>`
 
 ### Example
 
@@ -145,6 +146,13 @@ If the subscription cannot be renewed (e.g. due to an expired payment method), a
 By clicking on the _Wallet_ menu item you can see the list of your saved credit cards (if any).
 
 ![my-account-wallet](https://github.com/commercelayer/mfe-my-account/assets/105653649/23fb4719-37ae-47b8-965d-4b472d4a58bf)
+
+
+### Back to shop
+
+You could optionally provide a `returnURL` URL parameter to enable a *Back to shop* navigation link.
+
+`https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9&lang=en&returnUrl=https://yourbrand.com`
 
 ## Using the CLI to get a valid customer token
 

--- a/packages/my-account/README.md
+++ b/packages/my-account/README.md
@@ -12,8 +12,8 @@ The Commerce Layer My Account application (React) provides a production-ready re
 
 - [Getting started](#getting-started)
 - [Hosted version](#hosted-version)
-- [Localization](#localization)
 - [Features](#features)
+- [Localization](#localization)
 - [Using the CLI to get a valid customer token](#using-the-cli-to-get-a-valid-customer-token)
 - [Contributors guide](#contributors-guide)
 - [Help and support](#need-help)
@@ -48,15 +48,6 @@ You can use the hosted version of the My Account application with the following 
 ### Example
 
 `https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9`
-
-## Localization
-
-The application is actually localized in `en`, `it` and `nl` locales.
-You could optionally provide a `lang` URL parameter to define the locale used to localize the app: `https://<your-organization-subdomain>.commercelayer.app/my-account/?accessToken=<your-access-token>&lang=<short-lang-code>`
-
-### Example
-
-`https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9&lang=en`
 
 ## Features
 
@@ -156,6 +147,14 @@ You could optionally provide a `returnURL` URL parameter to enable a *Back to sh
 
 ![my-account-orders-back-to-shop](https://github.com/user-attachments/assets/f6481d5a-7377-4715-bddf-bf867d5ecdcc)
 
+## Localization
+
+The application is actually localized in `en`, `it` and `nl` locales.
+You could optionally provide a `lang` URL parameter to define the locale used to localize the app: `https://<your-organization-subdomain>.commercelayer.app/my-account/?accessToken=<your-access-token>&lang=<short-lang-code>`
+
+### Example
+
+`https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9&lang=en`
 
 ## Using the CLI to get a valid customer token
 

--- a/packages/my-account/README.md
+++ b/packages/my-account/README.md
@@ -154,6 +154,9 @@ You could optionally provide a `returnURL` URL parameter to enable a *Back to sh
 
 `https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9&lang=en&returnUrl=https://yourbrand.com`
 
+![my-account-orders-back-to-shop](https://github.com/user-attachments/assets/f6481d5a-7377-4715-bddf-bf867d5ecdcc)
+
+
 ## Using the CLI to get a valid customer token
 
 If you are using the [Commerce Layer CLI](https://github.com/commercelayer/commercelayer-cli) you can easily obtain a valid access token suitable for the generation of a My Account application working URL.

--- a/packages/my-account/src/App.tsx
+++ b/packages/my-account/src/App.tsx
@@ -46,7 +46,8 @@ function App(): JSX.Element {
                       <Redirect
                         to={appRoutes.orders.makePath({
                           accessToken: settings.accessToken ?? '',
-                          lang: settings.language
+                          lang: settings.language,
+                          returnUrl: settings.returnUrl
                         })}
                       />
                     </Route>
@@ -67,7 +68,8 @@ function App(): JSX.Element {
                         <Redirect
                           to={appRoutes.orders.makePath({
                             accessToken: settings.accessToken ?? '',
-                            lang: settings.language
+                            lang: settings.language,
+                            returnUrl: settings.returnUrl
                           })}
                         />
                       )}

--- a/packages/my-account/src/assets/locales/en/common.json
+++ b/packages/my-account/src/assets/locales/en/common.json
@@ -22,6 +22,7 @@
     "walletDescription": "Manage your payment methods",
     "returns": "Returns",
     "returnsDescription": "Return a product",
+    "backToShop": "Back to shop",
     "customerService": "Customer Service",
     "customerServiceDescription": "Get help from the seller",
     "logout": "Logout",

--- a/packages/my-account/src/assets/locales/it/common.json
+++ b/packages/my-account/src/assets/locales/it/common.json
@@ -22,6 +22,7 @@
     "walletDescription": "Gestisci i tuoi metodi di pagamento",
     "returns": "Resi",
     "returnsDescription": "Rendi un prodotto",
+    "backToShop": "Torna allo shop",
     "customerService": "Customer Service",
     "customerServiceDescription": "Richiedi aiuto al venditore",
     "logout": "Esci",

--- a/packages/my-account/src/assets/locales/nl/common.json
+++ b/packages/my-account/src/assets/locales/nl/common.json
@@ -22,6 +22,7 @@
       "walletDescription": "Beheer je betaalmethoden",
       "returns": "Retourzendingen",
       "returnsDescription": "Een product retourneren",
+      "backToShop": "Terug naar de winkel",
       "customerService": "Klantenservice",
       "customerServiceDescription": "Krijg hulp van de verkoper",
       "logout": "Uitloggen",

--- a/packages/my-account/src/components/composite/Address/CustomerAddressForm/index.tsx
+++ b/packages/my-account/src/components/composite/Address/CustomerAddressForm/index.tsx
@@ -111,6 +111,7 @@ function CustomerAddressForm(): JSX.Element | null {
               `${appRoutes.addresses.makePath({
                 accessToken: appCtx?.accessToken ?? '',
                 lang: settings.language,
+                returnUrl: settings.returnUrl
               })}`
             )
           }}
@@ -126,6 +127,7 @@ function CustomerAddressForm(): JSX.Element | null {
               `${appRoutes.addresses.makePath({
                 accessToken: appCtx?.accessToken ?? '',
                 lang: settings.language,
+                returnUrl: settings.returnUrl
               })}`
             )
           }}

--- a/packages/my-account/src/components/composite/NavLink/index.tsx
+++ b/packages/my-account/src/components/composite/NavLink/index.tsx
@@ -5,9 +5,8 @@ import { useRouter, useLocation, Link } from "wouter"
 import { Wrapper, Icon, TitleWrapper, Title, ComingSoon } from "./styled"
 
 import { AppContext } from "#providers/AppProvider"
-import { useSettings } from "#providers/SettingsProvider"
 
-type Props = Pick<Settings, "accessToken"> & {
+type Props = Partial<Pick<Settings, "accessToken">> & {
   id: string
   title: string
   href: string
@@ -48,18 +47,20 @@ function NavLinkButton(props: Props): JSX.Element {
 
 function NavLink(props: Props): JSX.Element {
   const { href, comingSoon } = props
-
   const ctx = useContext(AppContext)
+  
+  const LinkComponent = href.includes("://") ? "a" : Link;
 
   if (comingSoon) return <NavLinkButton {...props} />
 
+
   return (
-    <Link
+    <LinkComponent
       href={href}
       onClick={() => ctx?.closeMobileMenu()}
     >
       <NavLinkButton {...props} />
-    </Link>
+    </LinkComponent>
   )
 }
 

--- a/packages/my-account/src/components/composite/Navbar/index.tsx
+++ b/packages/my-account/src/components/composite/Navbar/index.tsx
@@ -6,7 +6,8 @@ import {
   Lifebuoy,
   MapPin,
   ShoppingCart,
-  CalendarCheck
+  CalendarCheck,
+  ArrowUUpLeft
 } from "phosphor-react"
 import { useTranslation } from "react-i18next"
 
@@ -34,7 +35,7 @@ interface Props {
 
 function Navbar({ settings, onClick }: Props): JSX.Element {
   const { t } = useTranslation()
-  const { accessToken, logoUrl, companyName, language } = settings
+  const { accessToken, logoUrl, companyName, language, returnUrl } = settings
 
   const menu = {
     orders: {
@@ -42,6 +43,7 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       href: appRoutes.orders.makePath({
         accessToken: accessToken ?? "",
         lang: language,
+        returnUrl,
       }),
       // icon: <ShoppingCartIcon />,
       icon: <ShoppingCart className="w-4" />,
@@ -54,6 +56,7 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       href: appRoutes.addresses.makePath({
         accessToken: accessToken ?? "",
         lang: language,
+        returnUrl
       }),
       icon: <MapPin className="w-4" />,
       comingSoon: false,
@@ -65,6 +68,7 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       href: appRoutes.subscriptions.makePath({
         accessToken: accessToken ?? "",
         lang: language,
+        returnUrl
       }),
       icon: <CalendarCheck className="w-4" />,
       comingSoon: false,
@@ -76,6 +80,7 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       href: appRoutes.wallet.makePath({
         accessToken: accessToken ?? "",
         lang: language,
+        returnUrl
       }),
       icon: <CreditCard className="w-4" />,
       comingSoon: false,
@@ -91,13 +96,18 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       accessToken,
       onClick,
     },
+    backToShop: {
+      title: t("menu.backToShop"),
+      href: returnUrl ?? '#',
+      icon: <ArrowUUpLeft className="w-4" />,
+    },
     customerService: {
       title: t("menu.customerService"),
       href: "/customer_service",
       icon: <Lifebuoy className="w-4" />,
       accessToken,
       onClick,
-    },
+    }
   }
 
   return (
@@ -118,7 +128,11 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
             <NavLink id="wallet" {...menu.wallet} />
             <NavLink id="returns" {...menu.returns} />
           </Nav>
-          {/* <NavLink id="customerService" {...menu.customerService} /> */}
+          <Nav>
+            {returnUrl != null && (
+              <NavLink id="backToShop" {...menu.backToShop} />
+            )}
+          </Nav>
           <EmailWrapper>
             {t("menu.loggedInAs")}
             <Email>

--- a/packages/my-account/src/components/composite/Order/OrderShipments/index.tsx
+++ b/packages/my-account/src/components/composite/Order/OrderShipments/index.tsx
@@ -78,7 +78,8 @@ function ParcelLink(): JSX.Element {
                 orderId: orderId ?? '',
                 parcelId: props?.attributeValue ?? '',
                 accessToken: accessToken ?? '',
-                lang: settings.language
+                lang: settings.language,
+                returnUrl: settings.returnUrl
               }))
             }
           />

--- a/packages/my-account/src/components/composite/Subscription/SubscriptionOrders/index.tsx
+++ b/packages/my-account/src/components/composite/Subscription/SubscriptionOrders/index.tsx
@@ -110,7 +110,8 @@ function SubscriptionOrders({ orderSubscription }: Props) {
                         href={appRoutes.order.makePath({
                           orderId: order.id ?? "",
                           accessToken: accessToken ?? '',
-                          lang: settings.language
+                          lang: settings.language,
+                          returnUrl: settings.returnUrl
                         })}
                       >
                         <OrderNumber>#{order.number}</OrderNumber>

--- a/packages/my-account/src/components/ui/AddressCard/index.tsx
+++ b/packages/my-account/src/components/ui/AddressCard/index.tsx
@@ -107,6 +107,7 @@ export function AddressCard({
                       addressId: address?.id || "",
                       accessToken: appCtx?.accessToken ?? '',
                       lang: settings.language,
+                      returnUrl: settings.returnUrl
                     })
                   )
                 }}

--- a/packages/my-account/src/data/routes.ts
+++ b/packages/my-account/src/data/routes.ts
@@ -1,8 +1,10 @@
-import path from "path"
-
 export type AppRoute = keyof typeof appRoutes
-type RouteParams = { accessToken: string, lang: string }
+type RouteParams = { accessToken: string, lang: string, returnUrl?: string }
 
+export const makeUrlParams = ({ accessToken, lang, returnUrl }: RouteParams): string => {
+  const urlParams = `accessToken=${accessToken}&lang=${lang}`
+  return urlParams + (returnUrl ? `&returnUrl=${encodeURIComponent(returnUrl)}` : "")
+} 
 
 // Object to be used as source of truth to handel application routes
 // each page should correspond to a key and each key should have
@@ -11,38 +13,38 @@ type RouteParams = { accessToken: string, lang: string }
 export const appRoutes = {
   orders: {
     path: "/orders",
-    makePath: ({ accessToken, lang }: RouteParams) => `/orders?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ accessToken, lang, returnUrl }: RouteParams) => `/orders?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   order: {
     path: "/orders/:orderId",
-    makePath: ({ orderId, accessToken, lang }: RouteParams & { orderId: string }) => `/orders/${orderId}?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ orderId, accessToken, lang, returnUrl }: RouteParams & { orderId: string }) => `/orders/${orderId}?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   parcel: {
     path: "/orders/:orderId/parcels/:parcelId",
-    makePath: ({ orderId, parcelId, accessToken, lang }: RouteParams & { orderId: string, parcelId: string }) => `/orders/${orderId}/parcels/${parcelId}?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ orderId, parcelId, accessToken, lang, returnUrl }: RouteParams & { orderId: string, parcelId: string }) => `/orders/${orderId}/parcels/${parcelId}?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   subscriptions: {
     path: "/subscriptions",
-    makePath: ({ accessToken, lang }: RouteParams) => `/subscriptions?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ accessToken, lang, returnUrl }: RouteParams) => `/subscriptions?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   subscription: {
     path: "/subscriptions/:subscriptionId",
-    makePath: ({ subscriptionId, accessToken, lang }: RouteParams & { subscriptionId: string }) => `/subscriptions/${subscriptionId}?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ subscriptionId, accessToken, lang, returnUrl }: RouteParams & { subscriptionId: string }) => `/subscriptions/${subscriptionId}?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   addresses: {
     path: "/addresses",
-    makePath: ({ accessToken, lang }: RouteParams) => `/addresses?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ accessToken, lang, returnUrl }: RouteParams) => `/addresses?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   newAddress: {
     path: "/addresses/new",
-    makePath: ({ accessToken, lang }: RouteParams) => `/addresses/new?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ accessToken, lang, returnUrl }: RouteParams) => `/addresses/new?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   editAddress: {
     path: "/addresses/:addressId/edit",
-    makePath: ({ addressId, accessToken, lang }: RouteParams & { addressId: string }) => `/addresses/${addressId}/edit?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ addressId, accessToken, lang, returnUrl }: RouteParams & { addressId: string }) => `/addresses/${addressId}/edit?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
   wallet: {
     path: "/wallet",
-    makePath: ({ accessToken, lang }: RouteParams) => `/wallet?accessToken=${accessToken}&lang=${lang}`,
+    makePath: ({ accessToken, lang, returnUrl }: RouteParams) => `/wallet?${makeUrlParams({ accessToken, lang, returnUrl })}`,
   },
 }

--- a/packages/my-account/src/pages/AddressesPage/index.tsx
+++ b/packages/my-account/src/pages/AddressesPage/index.tsx
@@ -32,6 +32,7 @@ function AddressesPage(): JSX.Element {
             `${appRoutes.newAddress.makePath({
               accessToken: appCtx?.accessToken ?? '',
               lang: settings.language,
+              returnUrl: settings.returnUrl
             })}`
           )
         }}

--- a/packages/my-account/src/pages/OrderPage/index.tsx
+++ b/packages/my-account/src/pages/OrderPage/index.tsx
@@ -43,7 +43,8 @@ function OrderPage({ orderId }: OrderPageProps): JSX.Element {
           {isInvalid ? (
             <Redirect to={appRoutes.orders.makePath({
               accessToken: accessToken ?? '',
-              lang: settings.language
+              lang: settings.language,
+              returnUrl: settings.returnUrl
             })} />
           ) : (
             <OrderContainer orderId={orderId}>

--- a/packages/my-account/src/pages/OrdersPage/index.tsx
+++ b/packages/my-account/src/pages/OrdersPage/index.tsx
@@ -96,7 +96,8 @@ function OrdersPage(): JSX.Element {
                           href={appRoutes.order.makePath({
                             orderId: order.id ?? "",
                             accessToken: accessToken ?? '',
-                            lang: settings.language
+                            lang: settings.language,
+                            returnUrl: settings.returnUrl
                           })}
                         >
                           <OrderNumber># {order.number}</OrderNumber>

--- a/packages/my-account/src/pages/ParcelPage/index.tsx
+++ b/packages/my-account/src/pages/ParcelPage/index.tsx
@@ -52,7 +52,8 @@ function ParcelPage({ orderId, parcelId }: Props): JSX.Element {
           {isInvalid ? (
             <Redirect to={appRoutes.orders.makePath({
               accessToken: accessToken ?? '',
-              lang: settings.language
+              lang: settings.language,
+              returnUrl: settings.returnUrl
             })} />
           ) : (
             <OrderContainer orderId={orderId}>
@@ -66,7 +67,8 @@ function ParcelPage({ orderId, parcelId }: Props): JSX.Element {
                             href={appRoutes.subscription.makePath({
                               subscriptionId: orderId ?? "",
                               accessToken: accessToken ?? '',
-                              lang: settings.language
+                              lang: settings.language,
+                              returnUrl: settings.returnUrl
                             })}
                           >
                             <BackToOrder>

--- a/packages/my-account/src/pages/SubscriptionPage/index.tsx
+++ b/packages/my-account/src/pages/SubscriptionPage/index.tsx
@@ -49,7 +49,8 @@ function SubscriptionPage({
   if (subscriptionId == null) {
     return <Redirect to={appRoutes.subscriptions.makePath({
       accessToken: accessToken ?? '',
-      lang: settings.language
+      lang: settings.language,
+      returnUrl: settings.returnUrl
     })} />
   }
 
@@ -70,7 +71,8 @@ function SubscriptionPage({
             {isInvalid ? (
               <Redirect to={appRoutes.subscriptions.makePath({
                 accessToken: accessToken ?? '',
-                lang: settings.language
+                lang: settings.language,
+                returnUrl: settings.returnUrl
               })} />
             ) : (
               <>

--- a/packages/my-account/src/pages/SubscriptionsPage/index.tsx
+++ b/packages/my-account/src/pages/SubscriptionsPage/index.tsx
@@ -101,7 +101,8 @@ function SubscriptionsPage(): JSX.Element {
                           href={appRoutes.subscription.makePath({
                             subscriptionId: order.id ?? "",
                             accessToken: accessToken ?? '',
-                            lang: settings.language
+                            lang: settings.language,
+                            returnUrl: settings.returnUrl
                           })}
                         >
                           <OrderNumber># {order.number}</OrderNumber>

--- a/packages/my-account/src/types/Settings.d.ts
+++ b/packages/my-account/src/types/Settings.d.ts
@@ -50,6 +50,10 @@ declare module "HostedApp" {
      */
     language: string
     /**
+     * The optional return URL to be used when the user is redirected back to the shop.
+     */
+    returnUrl?: string
+    /**
      * Customer Id information picked by owner?.id property inside parsed accessToken.
      * Read more at {@link https://docs.commercelayer.io/core/authentication/password}
      */
@@ -68,7 +72,7 @@ declare module "HostedApp" {
 
   type InvalidSettings = Pick<
     Settings,
-    "primaryColor" | "language" | "companyName" | "logoUrl" | "faviconUrl"
+    "primaryColor" | "language" | "returnUrl" | "companyName" | "logoUrl" | "faviconUrl"
   > & {
     /**
      * This flag allows TypeScript to discriminate between `Settings` and `InvalidSettings` union type.

--- a/packages/my-account/src/utils/getSettings.ts
+++ b/packages/my-account/src/utils/getSettings.ts
@@ -11,6 +11,7 @@ export const defaultSettings: InvalidSettings = {
   isValid: false,
   primaryColor: "#000000",
   language: "en",
+  returnUrl: undefined,
   faviconUrl:
     "https://data.commercelayer.app/assets/images/favicons/favicon-32x32.png",
   companyName: "Commerce Layer",
@@ -83,6 +84,7 @@ export const getSettings = async ({
   }
 
   const lang = new URLSearchParams(window.location.search).get('lang')
+  const returnUrl = new URLSearchParams(window.location.search).get('returnUrl')
 
   return {
     accessToken,
@@ -92,6 +94,7 @@ export const getSettings = async ({
     isValid: true,
     companyName: organization?.name || defaultSettings.companyName,
     language: lang ?? defaultSettings.language,
+    returnUrl: returnUrl ?? defaultSettings.returnUrl,
     primaryColor:
       (organization?.primary_color as string) || defaultSettings.primaryColor,
     logoUrl: organization?.logo_url || "",


### PR DESCRIPTION
Closes #158

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support for `Back to shop` navigation link activated by the optional `returnUrl` URL parameter.

<img width="300" alt="MyAccount - Back to shop" src="https://github.com/user-attachments/assets/7bece756-bc92-434b-a528-8849cb5df62d" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
