### PR TITLE
Add `Logout` link

### DIFF
--- a/packages/my-account/README.md
+++ b/packages/my-account/README.md
@@ -139,13 +139,14 @@ By clicking on the _Wallet_ menu item you can see the list of your saved credit 
 ![my-account-wallet](https://github.com/commercelayer/mfe-my-account/assets/105653649/23fb4719-37ae-47b8-965d-4b472d4a58bf)
 
 
-### Back to shop
+### Back to shop and Logout
 
 You could optionally provide a `returnURL` URL parameter to enable *Back to shop* and *Logout* navigation links.
 
 `https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9&lang=en&returnUrl=https://yourbrand.com`
 
-![my-account-orders-back-to-shop](https://github.com/user-attachments/assets/f6481d5a-7377-4715-bddf-bf867d5ecdcc)
+![my-account-orders-back-to-shop-logout](https://github.com/user-attachments/assets/668d0383-34fb-42ff-8fbf-bc2287862603)
+
 
 ## Localization
 

--- a/packages/my-account/README.md
+++ b/packages/my-account/README.md
@@ -141,7 +141,7 @@ By clicking on the _Wallet_ menu item you can see the list of your saved credit 
 
 ### Back to shop
 
-You could optionally provide a `returnURL` URL parameter to enable a *Back to shop* navigation link.
+You could optionally provide a `returnURL` URL parameter to enable *Back to shop* and *Logout* navigation links.
 
 `https://yourbrand.commercelayer.app/my-account?accessToken=eyJhbGciOiJIUzUxMiJ9&lang=en&returnUrl=https://yourbrand.com`
 

--- a/packages/my-account/package.json
+++ b/packages/my-account/package.json
@@ -41,6 +41,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
+    "@commercelayer/js-auth": "^6.7.2",
     "@commercelayer/react-components": "4.25.0",
     "@commercelayer/sdk": "^6.44.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",

--- a/packages/my-account/src/components/composite/Navbar/index.tsx
+++ b/packages/my-account/src/components/composite/Navbar/index.tsx
@@ -7,6 +7,7 @@ import {
   MapPin,
   ShoppingCart,
   CalendarCheck,
+  SignOut,
   ArrowUUpLeft
 } from "phosphor-react"
 import { useTranslation } from "react-i18next"
@@ -27,6 +28,7 @@ import NavLink from "#components/composite/NavLink"
 import Footer from "#components/ui/Footer"
 import Logo from "#components/ui/Logo"
 import { appRoutes } from "#data/routes"
+import { revokeCustomerToken } from "#utils/revokeCustomerToken"
 
 interface Props {
   settings: Settings
@@ -107,6 +109,18 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       icon: <Lifebuoy className="w-4" />,
       accessToken,
       onClick,
+    },
+    logout: {
+      title: t("menu.logout"),
+      href: '#',
+      icon: <SignOut className="w-4" />,
+      onClick: () => {
+        revokeCustomerToken(accessToken ?? "").then(() => {
+          if (returnUrl != null) {
+            window.location.replace(returnUrl)
+          }
+        })
+      }
     }
   }
 
@@ -131,6 +145,9 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
           <Nav>
             {returnUrl != null && (
               <NavLink id="backToShop" {...menu.backToShop} />
+            )}
+            {returnUrl != null && (
+              <NavLink id="logout" {...menu.logout} />
             )}
           </Nav>
           <EmailWrapper>

--- a/packages/my-account/src/utils/revokeCustomerToken.ts
+++ b/packages/my-account/src/utils/revokeCustomerToken.ts
@@ -1,0 +1,18 @@
+import { jwtDecode, revoke, type RevokeReturn } from "@commercelayer/js-auth"
+
+/**
+ * Revoke the customer access token.
+ * This function decodes the access token to extract the client ID
+ * and then calls the revoke function from @commercelayer/js-auth.
+ *
+ * @param {string} token - The access token to be revoked.
+ * @returns {Promise<RevokeReturn>} - A promise that resolves with the result of the revoke operation.
+ */
+export function revokeCustomerToken(token: string): Promise<RevokeReturn> {
+  const decoded = jwtDecode(token)
+  const clientId = decoded.payload.application.client_id
+  return revoke({
+    clientId,
+    token,
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   packages/my-account:
     dependencies:
+      '@commercelayer/js-auth':
+        specifier: ^6.7.2
+        version: 6.7.2
       '@commercelayer/react-components':
         specifier: 4.25.0
         version: 4.25.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(typescript@5.8.3)
@@ -177,9 +180,6 @@ importers:
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint-import-resolver-typescript@4.4.3)(eslint@9.29.0(jiti@1.21.6))(react@18.3.1)(typescript@5.8.3)
-      '@commercelayer/js-auth':
-        specifier: ^6.7.2
-        version: 6.7.2
       '@faker-js/faker':
         specifier: ^9.8.0
         version: 9.8.0


### PR DESCRIPTION
Closes #156

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support for `Logout` navigation link activated by the previously added `returnUrl` optional URL parameter.
Once the `Logout` link is clicked the customer access token is revoked before to navigate to `returnUrl`.

<img width="300" alt="Screenshot 2025-07-08 alle 11 39 52" src="https://github.com/user-attachments/assets/02eb9af4-da9e-4197-a24d-92fccbefac3b" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
