### PR TITLE
Add support to `hide_subscriptions` configuration

### DIFF
--- a/packages/my-account/src/App.tsx
+++ b/packages/my-account/src/App.tsx
@@ -28,6 +28,7 @@ function App(): JSX.Element {
       <Router base={basePath}>
         <SettingsProvider config={window.clAppConfig}>
           {({ settings, isLoading }) => {
+            const hideSubscriptions = settings?.config?.my_account?.hide_subscriptions ?? false
             return isLoading ? (
               <Skeleton />
             ) : !settings.isValid ? (
@@ -84,20 +85,24 @@ function App(): JSX.Element {
                         </Suspense>
                       )}
                     </Route>
-                    <Route path={appRoutes.subscriptions.path}>
-                      <Suspense fallback={<></>}>
-                        <LazySubscriptionsPage />
-                      </Suspense>
-                    </Route>
-                    <Route path={"/subscriptions/:subscriptionId"}>
-                      {(params) => (
-                        <Suspense fallback={<></>}>
-                          <LazySubscriptionPage
-                            subscriptionId={params.subscriptionId}
-                          />
-                        </Suspense>
-                      )}
-                    </Route>
+                    {!hideSubscriptions && (
+                      <>
+                        <Route path={appRoutes.subscriptions.path}>
+                          <Suspense fallback={<></>}>
+                            <LazySubscriptionsPage />
+                          </Suspense>
+                        </Route>
+                        <Route path={"/subscriptions/:subscriptionId"}>
+                          {(params) => (
+                            <Suspense fallback={<></>}>
+                              <LazySubscriptionPage
+                                subscriptionId={params.subscriptionId}
+                              />
+                            </Suspense>
+                          )}
+                        </Route>
+                      </>
+                    )}
                     <Route path={appRoutes.newAddress.path}>
                       <Suspense fallback={<></>}>
                         <LazyAddressFormPage />

--- a/packages/my-account/src/components/composite/Navbar/index.tsx
+++ b/packages/my-account/src/components/composite/Navbar/index.tsx
@@ -37,7 +37,8 @@ interface Props {
 
 function Navbar({ settings, onClick }: Props): JSX.Element {
   const { t } = useTranslation()
-  const { accessToken, logoUrl, companyName, language, returnUrl } = settings
+  const { accessToken, logoUrl, companyName, language, returnUrl, config } = settings
+  const hideSubscriptions = config?.my_account?.hide_subscriptions ?? false
 
   const menu = {
     orders: {
@@ -138,7 +139,9 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
           <Nav>
             <NavLink id="orders" {...menu.orders} />
             <NavLink id="addresses" {...menu.addresses} />
-            <NavLink id="subscriptions" {...menu.subscriptions} />
+            {!hideSubscriptions && (
+              <NavLink id="subscriptions" {...menu.subscriptions} />
+            )}
             <NavLink id="wallet" {...menu.wallet} />
             <NavLink id="returns" {...menu.returns} />
           </Nav>


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/458

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support to `hide_subscriptions` configuration setting in `my_account` section of organization MFE config.
If the `hide_subscriptions` entry is set to `true` the `subscriptions` navigation menu item won't be visibile and it will be removed any `subscriptions` related route.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
