### PR TITLE
Fix desktop position of status column in orders list

### DIFF
--- a/packages/my-account/src/pages/OrdersPage/index.tsx
+++ b/packages/my-account/src/pages/OrdersPage/index.tsx
@@ -134,7 +134,7 @@ function OrdersPage(): JSX.Element {
           </OrderListRow>
           <OrderListRow
             field="status"
-            className="absolute order-3 left-5 bottom-4 md:bottom-auto md:relative"
+            className="absolute order-3 left-5 bottom-4 md:left-auto md:bottom-auto md:relative"
           >
             {({ cell, row, ...p }) => {
               const order = row?.original


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed desktop position of status column in orders list due to a missing CSS classname.